### PR TITLE
Refactor lists and change header colors on About Us

### DIFF
--- a/components/SubPage/FAQ/OneFaq.js
+++ b/components/SubPage/FAQ/OneFaq.js
@@ -2,7 +2,11 @@ export default function OneFaq (props) {
     return (
         <div>
             <div className="py-4">
-                <h4 className=" text-2xl font-bold mb-4 tracking-tight text-uablue-default">{props.title}</h4>
+                <h4 
+                    className={"text-2xl font-bold mb-4 tracking-tight " + (props.titleBlack ? '' : "text-uablue-default")}
+                >
+                    {props.title}
+                </h4>
                 {props.children}
             </div>
         </div>

--- a/pages/about-us.js
+++ b/pages/about-us.js
@@ -5,6 +5,7 @@ import Layout from "../components/layout";
 import OneFaq from "../components/SubPage/FAQ/OneFaq";
 import Hero from "../components/SubPage/Hero/hero";
 import Button from "../components/Button/button";
+import ListItem from '../components/List/listItem';
 
 export default function AboutUs() {
     const { t } = useTranslation('about-us')
@@ -23,86 +24,47 @@ export default function AboutUs() {
                             {t('about-us.faq-heading')}
                         </h1>
                         <OneFaq title={t('about-us.onefaq.donation-impact')}>
-                            <div className="flex flex-row items-center mb-4 gap-3">
-                                <span className="shrink-0 w-6">👉 </span>
-                                <span>
-                                    <p className="leading-tight">
-                                        {t('about-us.onefaq.donation-impact.section1')}
-                                    </p>
-                                </span>
-                            </div>
-                            <div className="flex flex-row items-center mb-4 gap-3">
-                                <span className="shrink-0 w-6">👉 </span>
-                                <span>
-                                    <p className="leading-tight">
-                                        {t('about-us.onefaq.donation-impact.section2')}
-                                    </p>
-                                </span>
-                            </div>
-                            <div className="flex flex-row items-center mb-4 gap-3">
-                                <span className="shrink-0 w-6">👉 </span>
-                                <span>
-
-                                    <p className="leading-tight">
-                                        {t('about-us.onefaq.donation-impact.section3')}
-                                    </p>
-                                </span>
-                            </div>
+                            <ul>
+                                <ListItem>{t('about-us.onefaq.donation-impact.section1')}</ListItem>
+                                <ListItem>{t('about-us.onefaq.donation-impact.section2')}</ListItem>
+                                <ListItem>{t('about-us.onefaq.donation-impact.section3')}</ListItem>
+                            </ul>                                                        
                         </OneFaq>
                         <OneFaq title={t('about-us.onefaq.credibility')}>
-                            <div className="flex flex-row items-center mb-4 gap-3">
-                                <span className="shrink-0 w-6">👉 </span>
-                                <span>
-                                    <p className="leading-tight">
-                                        {t('about-us.onefaq.credibility.section1')}
-                                    </p>
-                                </span>
-                            </div>
-                            <div className="flex flex-row items-center mb-4 gap-3">
-                                <span className="shrink-0 w-6">👉 </span>
-                                <span>
-                                    <p className="leading-tight">
-                                        {t('about-us.onefaq.credibility.section2')}{" "}
-                                        <Link href="/for-fundraisers/for-reputation-backers">
-                                            <a className="font-medium text-uablue-default underline underline-offset-4 hover:text-uablue-accent">
-                                                {t('about-us.onefaq.credibility.section2.link')}
-                                            </a>
-                                        </Link>
-                                    </p>
-                                </span>
-                            </div>
+                            <ul>
+                                <ListItem>{t('about-us.onefaq.credibility.section1')}</ListItem>
+                                <ListItem>
+                                    {t('about-us.onefaq.credibility.section2')}{" "}
+                                    <Link href="/for-fundraisers/for-reputation-backers">
+                                        <a className="font-medium text-uablue-default underline underline-offset-4 hover:text-uablue-accent">
+                                            {t('about-us.onefaq.credibility.section2.link')}
+                                        </a>
+                                    </Link>
+                                </ListItem>
+                            </ul>                                                        
                         </OneFaq>
                         <OneFaq title={t('about-us.onefaq.language-barrier')}>
-                            <div className="flex flex-row items-center mb-4 gap-3">
-                                <span className="shrink-0 w-6">👉 </span>
-                                <span>
-
-                                    <p className="leading-tight">
-                                        {t('about-us.onefaq.language-barrier.section1')}
-                                    </p>
-                                </span>
+                            <ul>
+                                <ListItem>{t('about-us.onefaq.language-barrier.section1')}</ListItem>
+                            </ul>                            
+                        </OneFaq>
+                        <OneFaq title={t('about-us.get-in-touch.heading')}>
+                            <p>
+                                {t('about-us.get-in-touch.description.section1')}
+                            </p>
+                            <br/>
+                            <p>
+                                {t('about-us.get-in-touch.description.section2')}
+                            </p>
+                            <br/>
+                            <div className="w-full sm:w-64">
+                                <Button
+                                    value={t('about-us.get-in-touch.contact-form')}
+                                    href="https://forms.gle/fENMLtLzqAxE3fwm6"
+                                    target="_blank"
+                                />
                             </div>
                         </OneFaq>
-                    </div>
-                    <div className="mt-8">
-                        <h1 className="font-bold text-2xl lg:text-4xl mb-4 text-uablue-default">
-                            {t('about-us.get-in-touch.heading')}
-                        </h1>
-                        <p>
-                            {t('about-us.get-in-touch.description.section1')}
-                        </p>
-                        <br/>
-                        <p>
-                            {t('about-us.get-in-touch.description.section2')}
-                        </p>
-                        <br/>
-                        <div className="w-full sm:w-64">
-                            <Button
-                                value={t('about-us.get-in-touch.contact-form')}
-                                href="https://forms.gle/fENMLtLzqAxE3fwm6"
-                                target="_blank"
-                            />
-                        </div>
                     </div>
                 </div>
             </div>

--- a/pages/about-us.js
+++ b/pages/about-us.js
@@ -20,17 +20,17 @@ export default function AboutUs() {
                 <div className="bg-gray-100 absolute right-0 py-8 px-6 sm:px-16 sm:mt-8 lg:pl-40 lg:pr-96">
                     <div className="mt-8">
                         <p>{t('about-us.description')}</p>
-                        <h1 className="font-bold text-2xl lg:text-4xl mb-4 mt-12 text-uablue-default">
+                        <h1 className="font-bold text-4xl lg:text-4xl mb-4 mt-12 text-uablue-default">
                             {t('about-us.faq-heading')}
                         </h1>
-                        <OneFaq title={t('about-us.onefaq.donation-impact')}>
+                        <OneFaq title={t('about-us.onefaq.donation-impact')} titleBlack>
                             <ul>
                                 <ListItem>{t('about-us.onefaq.donation-impact.section1')}</ListItem>
                                 <ListItem>{t('about-us.onefaq.donation-impact.section2')}</ListItem>
                                 <ListItem>{t('about-us.onefaq.donation-impact.section3')}</ListItem>
                             </ul>                                                        
                         </OneFaq>
-                        <OneFaq title={t('about-us.onefaq.credibility')}>
+                        <OneFaq title={t('about-us.onefaq.credibility')} titleBlack>
                             <ul>
                                 <ListItem>{t('about-us.onefaq.credibility.section1')}</ListItem>
                                 <ListItem>
@@ -43,7 +43,7 @@ export default function AboutUs() {
                                 </ListItem>
                             </ul>                                                        
                         </OneFaq>
-                        <OneFaq title={t('about-us.onefaq.language-barrier')}>
+                        <OneFaq title={t('about-us.onefaq.language-barrier')} titleBlack>
                             <ul>
                                 <ListItem>{t('about-us.onefaq.language-barrier.section1')}</ListItem>
                             </ul>                            

--- a/pages/for-donors.js
+++ b/pages/for-donors.js
@@ -3,6 +3,7 @@ import OneFaq from "../components/SubPage/FAQ/OneFaq";
 import Hero from "../components/SubPage/Hero/hero";
 import Link from "next/link";
 import Button from "../components/Button/button";
+import ListItem from "../components/List/listItem";
 
 export default function ForDonors() {
     return (
@@ -12,14 +13,12 @@ export default function ForDonors() {
                     title="For donors"
                     description="Helping you meaningfully support grassroots fundraising efforts for Ukraine."
                 />
+                <p>
+                    This project was created to find, evaluate and
+                    amplify credible fundraisers organized by Ukrainian
+                    volunteers.
+                </p>
                 <div className="bg-gray-100 absolute right-0 py-8 px-6 sm:px-16 sm:mt-8 lg:pl-40 lg:pr-96">
-                    <div className="mt-8">
-                        <p>
-                            This project was created to find, evaluate and
-                            amplify credible fundraisers organized by Ukrainian
-                            volunteers.
-                        </p>
-                    </div>
                     <div className="mt-16">
                         <h1 className="font-bold text-2xl lg:text-4xl mb-4 mt-8">
                             F.A.Q.
@@ -72,50 +71,38 @@ export default function ForDonors() {
                                     our vetting process.
                                 </li>
                             </ul>
-                            <div className="flex flex-row items-center mb-4 mt-4 gap-3">
-                                <span className="shrink-0 w-6">👉 </span>
-                                <span>
-                                    <p className=" leading-tight">
-                                        <strong>Disclaimer: </strong>
-                                        We are confident in fundraisers we have
-                                        vetted, but the final decision to donate
-                                        is yours. Before donating, double-check
-                                        the legitimacy of the social media page
-                                        hosting the fundraiser.
-                                    </p>
-                                </span>
-                            </div>
+                            <ul>
+                                <ListItem>                                    
+                                    <strong>Disclaimer: </strong>
+                                    We are confident in fundraisers we have
+                                    vetted, but the final decision to donate
+                                    is yours. Before donating, double-check
+                                    the legitimacy of the social media page
+                                    hosting the fundraiser.                           
+                                </ListItem>
+                            </ul>                                
                         </OneFaq>
                         <OneFaq title="How to donate?">
                             <p>
                                 Click “Donate Now” for deposit information. We
                                 are not hosting payment information directly on
-                                our website at the moment.
-                                <br></br>
-                                <br></br>
+                                our website at the moment.                                
                             </p>
-                            <div className="flex flex-row items-center mb-4 gap-3">
-                                <span className="shrink-0 w-6">👉 </span>
-                                <span>
-                                    <p className=" leading-tight">
-                                        <strong>
-                                            Donating to a Ukrainian card:
-                                        </strong>{" "}
-                                        Wise, SWIFT, Western Union
-                                    </p>
-                                </span>
-                            </div>
-                            <div className="flex flex-row items-center mb-4 gap-3">
-                                <span className="shrink-0 w-6">👉 </span>
-                                <span>
-                                    <p className=" leading-tight">
-                                        <strong>
-                                            Donating to a US-based account:
-                                        </strong>{" "}
-                                        Venmo, Paypal, Zelle, Revolut, CashApp
-                                    </p>
-                                </span>
-                            </div>
+                            <ul>
+                                <ListItem>
+                                    <strong>
+                                        Donating to a Ukrainian card:
+                                    </strong>{" "}
+                                    Wise, SWIFT, Western Union
+                                </ListItem>
+                                <ListItem>
+                                    <strong>
+                                        Donating to a US-based account:
+                                    </strong>{" "}
+                                    Venmo, Paypal, Zelle, Revolut, CashApp
+                                </ListItem>
+                            </ul>
+                            <br />
                             <div className="w-full sm:w-64">
                                 <Button
                                     value="See All Fundraisers"


### PR DESCRIPTION
Refactor all the list items on the site. We were using a couple different ways to style the lists with the 👉 icon. This change standardizes them so that we only need to change it in one place.

Also updated the colors of the headers on the About Us page to be in line with the Figma.